### PR TITLE
Addressee attention address improvements

### DIFF
--- a/lib/netsuite_integration/shipment.rb
+++ b/lib/netsuite_integration/shipment.rb
@@ -199,7 +199,7 @@ module NetsuiteIntegration
           best_name_guess = if address.ship_attention.present?
             address.ship_attention
           else
-            address.ship_addressee
+            address.ship_addressee || ''
           end
           
           firstname, lastname = best_name_guess.split(" ", 2)

--- a/lib/netsuite_integration/shipment.rb
+++ b/lib/netsuite_integration/shipment.rb
@@ -192,7 +192,7 @@ module NetsuiteIntegration
       end
 
       def build_shipping_address(address)
-        if address && address.ship_addressee
+        if address
           # if ship_attention is set, the addressee is most likely an organization
           # and the attenion field is the person the package is being sent to
           


### PR DESCRIPTION
In our NS instance, some item fulfillments don't have an `addressee` specified but do have a `attention`.

I've also ran into the case where neither are defined.

This change should handle both cases while being backwards compatible.